### PR TITLE
Fix path env for video processing

### DIFF
--- a/scripts/process_video.py
+++ b/scripts/process_video.py
@@ -92,6 +92,7 @@ def main() -> None:
         ],
         check=True,
         cwd=args.alphapose_dir,
+        env=dict(os.environ, PYTHONPATH=args.alphapose_dir),
     )
     # Move JSONs
     for f in os.listdir("alphapose_temp"):
@@ -126,6 +127,7 @@ def main() -> None:
             ],
             check=True,
             cwd=args.densepose_dir,
+            env=dict(os.environ, PYTHONPATH=args.densepose_dir),
         )
         moved = Path(output_img)
         if moved.exists():


### PR DESCRIPTION
## Summary
- handle missing `PYTHONPATH` in `process_video.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672668f0588326b7856770f0a50e03